### PR TITLE
Make uvloop optional and clean dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Bot puts reaction to new posts in the channel, group or chat. Reactions are set 
 * Automatically converts a `Telethon session to a Pyrogram session`.
 
 ## Launch Instructions
+This project is tested with **Python 3.11** and earlier. Newer Python releases
+may fail to build dependencies like `uvloop` or `cryptg`.
 1. Create an empty directory
 2. `git clone https://github.com/kanewi11/telegram-reaction-bot.git ./`.
 3. `python3 -m venv venv` or on windows `python -m venv venv`.

--- a/reactionbot.py
+++ b/reactionbot.py
@@ -20,8 +20,11 @@ from converters import SessionConvertor, convert_tdata
 
 
 if platform.system() != 'Windows':
-    import uvloop
-    uvloop.install()
+    try:
+        import uvloop
+        uvloop.install()
+    except Exception as exc:
+        logging.warning('Failed to use uvloop: %s', exc)
 
 
 TRY_AGAIN_SLEEP = 20

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,5 +6,4 @@ rsa==4.9
 Telethon==1.25.4
 TgCrypto==1.2.4
 uvloop==0.17.0
-loguru~=0.6.0
 cryptg~=0.4.0

--- a/requirements_win.txt
+++ b/requirements_win.txt
@@ -5,5 +5,4 @@ PySocks==1.7.1
 rsa==4.9
 Telethon==1.25.4
 TgCrypto==1.2.4
-loguru~=0.6.0
 cryptg~=0.4.0


### PR DESCRIPTION
## Summary
- allow running without uvloop
- remove unused loguru dependency
- normalize requirements files with trailing newline
- document Python 3.11 support in README

## Testing
- `python -m py_compile reactionbot.py`

------
https://chatgpt.com/codex/tasks/task_e_685d3218bb7083229232f93218019d37