### PR TITLE
Add default session config and API credentials

### DIFF
--- a/converters/tdata_to_telethon.py
+++ b/converters/tdata_to_telethon.py
@@ -15,8 +15,8 @@ from telethon.sessions import StringSession
 from .telethon_to_pyrogram import SessionConvertor
 
 
-API_HASH = 'api_hash'
-API_ID = 123456789
+API_HASH = '2d0729d2fed8e7a9425804f5e2c49deb'
+API_ID = 24881102
 
 DC_TABLE = {
     1: ('149.154.175.50', 443),

--- a/sessions/79376705862.json
+++ b/sessions/79376705862.json
@@ -1,0 +1,5 @@
+{
+    "api_id": 24881102,
+    "api_hash": "2d0729d2fed8e7a9425804f5e2c49deb",
+    "phone_number": "+79376705862"
+}


### PR DESCRIPTION
## Summary
- set provided API credentials in `tdata_to_telethon.py`
- add session JSON with the same credentials for phone `+79376705862`

## Testing
- `python -m py_compile converters/tdata_to_telethon.py sessions/79376705862.json`

------
https://chatgpt.com/codex/tasks/task_e_685f846761548322bb711f2d814ff1ba