### PR TITLE
Fix makefile indentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 .PHONY: setup add-account react start
 
 setup:
-./setup.sh
+	./setup.sh
 
 add-account:
-source venv/bin/activate && python app.py add-account
+	source venv/bin/activate && python app.py add-account
 
 react:
-source venv/bin/activate && python app.py react $(channel)
+	source venv/bin/activate && python app.py react $(channel)
 
 start:
-./start.sh
+	./start.sh


### PR DESCRIPTION
## Summary
- fix Makefile to use tabs for recipe commands

## Testing
- `make setup`
- `make add-account` *(fails: `/bin/sh: 1: source: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685fd4341d6883229cd6858a5c1c74b1